### PR TITLE
Add llama.cpp engine for GGUF models

### DIFF
--- a/exo/inference/inference_engine.py
+++ b/exo/inference/inference_engine.py
@@ -54,6 +54,7 @@ class InferenceEngine(ABC):
 inference_engine_classes = {
   "mlx": "MLXDynamicShardInferenceEngine",
   "tinygrad": "TinygradDynamicShardInferenceEngine",
+  "llama_cpp": "LlamaCppInferenceEngine",
   "dummy": "DummyInferenceEngine",
 }
 
@@ -71,6 +72,9 @@ def get_inference_engine(inference_engine_name: str, shard_downloader: ShardDown
     tinygrad.helpers.DEBUG.value = int(os.getenv("TINYGRAD_DEBUG", default="0"))
 
     return TinygradDynamicShardInferenceEngine(shard_downloader)
+  elif inference_engine_name == "llama_cpp":
+    from exo.inference.llama_cpp.inference import LlamaCppInferenceEngine
+    return LlamaCppInferenceEngine(shard_downloader)
   elif inference_engine_name == "dummy":
     from exo.inference.dummy_inference_engine import DummyInferenceEngine
     return DummyInferenceEngine()

--- a/exo/inference/llama_cpp/__init__.py
+++ b/exo/inference/llama_cpp/__init__.py
@@ -1,0 +1,3 @@
+from .inference import LlamaCppInferenceEngine
+
+__all__ = ["LlamaCppInferenceEngine"]

--- a/exo/inference/llama_cpp/inference.py
+++ b/exo/inference/llama_cpp/inference.py
@@ -1,0 +1,56 @@
+import numpy as np
+from pathlib import Path
+from typing import Optional
+
+from llama_cpp import Llama
+
+from exo.inference.inference_engine import InferenceEngine
+from exo.inference.shard import Shard
+from exo.download.shard_download import ShardDownloader
+
+class LlamaCppInferenceEngine(InferenceEngine):
+    def __init__(self, shard_downloader: ShardDownloader):
+        self.shard_downloader = shard_downloader
+        self.shard: Optional[Shard] = None
+        self.model: Optional[Llama] = None
+        self.tokenizer = None
+
+    async def ensure_shard(self, shard: Shard):
+        if self.shard == shard:
+            return
+        model_path = await self.shard_downloader.ensure_shard(shard, self.__class__.__name__)
+        if Path(model_path).is_dir():
+            ggufs = list(Path(model_path).glob('*.gguf'))
+            if len(ggufs) == 0:
+                raise FileNotFoundError('No .gguf file found in %s' % model_path)
+            model_path = ggufs[0]
+        self.model = Llama(model_path=str(model_path), logits_all=True)
+        self.tokenizer = self.model
+        self.shard = shard
+
+    async def encode(self, shard: Shard, prompt: str) -> np.ndarray:
+        await self.ensure_shard(shard)
+        tokens = self.model.tokenize(prompt.encode('utf-8'), add_bos=False)
+        return np.array(tokens, dtype=np.int32)
+
+    async def decode(self, shard: Shard, tokens: np.ndarray) -> str:
+        await self.ensure_shard(shard)
+        return self.model.detokenize(tokens.tolist()).decode('utf-8')
+
+    async def sample(self, x: np.ndarray, temp: float = 0.0, top_p: float = 1.0) -> np.ndarray:
+        if x.ndim == 2:
+            logits = x[0]
+        else:
+            logits = x
+        token = int(np.argmax(logits))
+        return np.array([token], dtype=np.int32)
+
+    async def infer_tensor(self, request_id: str, shard: Shard, input_data: np.ndarray, inference_state: Optional[dict] = None) -> tuple[np.ndarray, Optional[dict]]:
+        await self.ensure_shard(shard)
+        tokens = input_data.reshape(-1).astype(int).tolist()
+        self.model.eval(tokens)
+        logits = self.model._scores[-1:]
+        return logits, None
+
+    async def load_checkpoint(self, shard: Shard, path: str):
+        pass

--- a/exo/main.py
+++ b/exo/main.py
@@ -81,7 +81,7 @@ parser.add_argument("--wait-for-peers", type=int, default=0, help="Number of pee
 parser.add_argument("--chatgpt-api-port", type=int, default=52415, help="ChatGPT API port")
 parser.add_argument("--chatgpt-api-response-timeout", type=int, default=900, help="ChatGPT API response timeout in seconds")
 parser.add_argument("--max-generate-tokens", type=int, default=10000, help="Max tokens to generate in each request")
-parser.add_argument("--inference-engine", type=str, default=None, help="Inference engine to use (mlx, tinygrad, or dummy)")
+parser.add_argument("--inference-engine", type=str, default=None, help="Inference engine to use (mlx, tinygrad, llama_cpp, or dummy)")
 parser.add_argument("--disable-tui", action=argparse.BooleanOptionalAction, help="Disable TUI")
 parser.add_argument("--run-model", type=str, help="Specify a model to run directly")
 parser.add_argument("--prompt", type=str, help="Prompt for the model when using --run-model", default="Who are you?")

--- a/exo/orchestration/node.py
+++ b/exo/orchestration/node.py
@@ -100,6 +100,8 @@ class Node:
     if self.inference_engine.__class__.__name__ == 'MLXDynamicShardInferenceEngine':
       supported_engine_names.append('mlx')
       supported_engine_names.append('tinygrad')
+    elif self.inference_engine.__class__.__name__ == 'LlamaCppInferenceEngine':
+      supported_engine_names.append('llama_cpp')
     else:
       supported_engine_names.append('tinygrad')
     return supported_engine_names

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ install_requires = [
   "transformers==4.46.3",
   "uuid==1.30",
   "uvloop==0.21.0",
+  "llama-cpp-python>=0.2.56",
   "tinygrad @ git+https://github.com/tinygrad/tinygrad.git@ec120ce6b9ce8e4ff4b5692566a683ef240e8bc8",
 ]
 


### PR DESCRIPTION
## Summary
- add LlamaCppInferenceEngine based on llama-cpp-python
- register new engine in inference framework and node
- extend CLI help and dependencies for llama.cpp

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_6843ea38d148832bac3d4a1c9ac8a0e9